### PR TITLE
Support `gpt-3.5-turbo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,29 @@ $ ata --help
 
 **How much will I have to pay for the API?**
 
-Using OpenAI's API is quite cheap, I have been using this terminal application heavily for a few weeks now and my costs are about $0.15 per day ($4.50 per month).
+Using OpenAI's API is quite cheap, I have been using this terminal application heavily for a few weeks now and my costs are about $0.01 per day ($0.30 per month).
 The first $18.00 for free, so you can use it for about 120 days (4 months) before having to pay.
+
+**How can I make `ata` easily available (without having to specify --config)?**
+
+You can wrap the binary to make it easily available.
+For example, when you have a system with Bash available, you can create the following file:
+
+```sh
+#!/usr/bin/env bash
+
+/path/to/ata/binary --config=/path/to/config/toml "$@"
+```
+
+and call it `ata.sh` and place it somewhere in your `PATH`.
+For example, at `~/.local/bin/ata.sh`.
+Next, you can use
+
+```sh
+$ ata
+```
+
+From anywhere on your system and have it automatically loaded with the right configuration.
 
 **Can I build the binary myself?**
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ $ ata --help
 
 **How much will I have to pay for the API?**
 
-Using OpenAI's API is quite cheap, I have been using this terminal application heavily for a few weeks now and my costs are about $0.02 per day ($0.30 per month).
 Using OpenAI's API for chat is very cheap.
 Let's say that an average response is about 500 tokens, so costs $0.001.
 That means that if you do 100 requests per day, then that will cost you about $0.10.

--- a/README.md
+++ b/README.md
@@ -69,27 +69,6 @@ $ ata --help
 Using OpenAI's API is quite cheap, I have been using this terminal application heavily for a few weeks now and my costs are about $0.01 per day ($0.30 per month).
 The first $18.00 for free, so you can use it for about 120 days (4 months) before having to pay.
 
-**How can I make `ata` easily available (without having to specify --config)?**
-
-You can wrap the binary to make it easily available.
-For example, when you have a system with Bash available, you can create the following file:
-
-```sh
-#!/usr/bin/env bash
-
-/path/to/ata/binary --config=/path/to/config/toml "$@"
-```
-
-and call it `ata.sh` and place it somewhere in your `PATH`.
-For example, at `~/.local/bin/ata.sh`.
-Next, you can use
-
-```sh
-$ ata
-```
-
-From anywhere on your system and have it automatically loaded with the right configuration.
-
 **Can I build the binary myself?**
 
 Yes, you can clone the repository and build the project via [`Cargo`](https://github.com/rust-lang/cargo).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center"><code>ata</code>: Ask the Terminal Anything</h1>
 
-<h3 align="center">OpenAI GPT in the terminal</h3>
+<h3 align="center">ChatGPT in the terminal</h3>
 
 <p align="center">
   <a href="https://asciinema.org/a/557270"><img src="https://asciinema.org/a/557270.svg" alt="asciicast"></a>
@@ -11,8 +11,6 @@ TIP:<br>
   Run a terminal with this tool in your background and show/hide it with a keypress.<br>
     This can be done via: Iterm2 (Mac), Guake (Ubuntu), scratchpad (i3/sway), or the quake mode for the Windows Terminal.
 </h3>
-
-At the time of writing, use `text-davinci-003`. Davinci was released together with ChatGPT as part of the [GPT-3.5 series](https://platform.openai.com/docs/model-index-for-researchers/models-referred-to-as-gpt-3-5) and they are very comparable in terms of capabilities; ChatGPT is more verbose.
 
 ## Productivity benefits
 
@@ -26,35 +24,11 @@ At the time of writing, use `text-davinci-003`. Davinci was released together wi
 Download the binary for your system from [Releases](https://github.com/rikhuijzer/ata/releases).
 If you're running Arch Linux, then you can use the AUR packages: [ata](https://aur.archlinux.org/packages/ata), [ata-git](https://aur.archlinux.org/packages/ata-git), or [ata-bin](https://aur.archlinux.org/packages/ata-bin).
 
-Request an API key via <https://beta.openai.com/account/api-keys>.
-Next, set the API key, the model that you want to use, and the maximum amount of tokens that the server can respond with in `ata.toml`:
+To specify the API key and some basic model settings, start the application.
+It should give an error and the option to create a configuration file called `ata.toml` for you.
+Press `y` and `ENTER` to create a `ata.toml` file.
 
-```toml
-api_key = "<YOUR SECRET API KEY>"
-model = "text-davinci-003"
-max_tokens = 500
-temperature = 0.8
-```
-
-Here, replace `<YOUR SECRET API KEY>` with your API key, which you can request via https://beta.openai.com/account/api-keys.
-
-The `max_tokens` sets the maximum amount of tokens that the server will answer with.
-
-The `temperature` sets the `sampling temperature`. From the OpenAI API docs: "What sampling temperature to use. Higher values means the model will take more risks. Try 0.9 for more creative applications, and 0 (argmax sampling) for ones with a well-defined answer." According to Stephen Wolfram [[1]], setting it to a higher value such as 0.8 will likely work best in practice.
-
-[1]: https://writings.stephenwolfram.com/2023/02/what-is-chatgpt-doing-and-why-does-it-work/
-
-Next, run:
-
-```sh
-$ ata --config=ata.toml
-```
-
-Or, change the current directory to the one where `ata.toml` is located and run
-
-```sh
-$ ata
-```
+Next, request an API key via <https://beta.openai.com/account/api-keys> and update the key in the example configuration file.
 
 For more information, see:
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,11 @@ $ ata --help
 
 **How much will I have to pay for the API?**
 
-Using OpenAI's API is quite cheap, I have been using this terminal application heavily for a few weeks now and my costs are about $0.01 per day ($0.30 per month).
-The first $18.00 for free, so you can use it for about 120 days (4 months) before having to pay.
+Using OpenAI's API is quite cheap, I have been using this terminal application heavily for a few weeks now and my costs are about $0.02 per day ($0.30 per month).
+Using OpenAI's API for chat is very cheap.
+Let's say that an average response is about 500 tokens, so costs $0.001.
+That means that if you do 100 requests per day, then that will cost you about $0.10.
+OpenAI grants you $18.00 for free, so you can use the API for about 180 days (6 months) before having to pay.
 
 **Can I build the binary myself?**
 

--- a/ata/Cargo.toml
+++ b/ata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ata"
-version = "1.0.3"
+version = "2.0.0"
 edition = "2021"
 authors = ["Rik Huijzer <t.h.huijzer@rug.nl>", "Fredrick R. Brennan <copypaste@kittens.ph>"]
 license = "MIT"

--- a/ata/Cargo.toml
+++ b/ata/Cargo.toml
@@ -6,14 +6,16 @@ authors = ["Rik Huijzer <t.h.huijzer@rug.nl>", "Fredrick R. Brennan <copypaste@k
 license = "MIT"
 
 [dependencies]
-rustyline = "10.1"
+clap = { version = "4.1.4", features = ["derive"] }
+directories = "4.0"
 hyper = { version = "0.14", features = ["full"] }
 hyper-rustls = { version = "0.23" }
+os_str_bytes = "6.4.1"
+rustyline = "10.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 tokio = { version = "1", features = ["full"] }
 toml = { version = "0.6" }
-clap = { version = "4.1.4", features = ["derive"] }
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/ata/src/config.rs
+++ b/ata/src/config.rs
@@ -1,0 +1,114 @@
+use directories::ProjectDirs;
+use os_str_bytes::OsStrBytes as _;
+use os_str_bytes::OsStringBytes as _;
+use serde::Deserialize;
+use std::convert::Infallible;
+use std::ffi::OsString;
+use std::path::Path;
+use std::path::PathBuf;
+use std::str::FromStr;
+use toml::de::Error as TomlError;
+
+#[derive(Clone, Deserialize, Debug)]
+pub struct Config {
+    pub api_key: String,
+    pub model: String,
+    pub max_tokens: i64,
+    pub temperature: f64
+}
+
+#[derive(Clone, Deserialize, Debug, Default)]
+pub enum ConfigLocation {
+    #[default]
+    Auto,
+    Path(PathBuf),
+    Named(PathBuf),
+}
+
+impl FromStr for ConfigLocation {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(if !s.contains('.') && !s.is_empty() {
+            Self::Named(s.into())
+        } else if !s.is_empty() {
+            Self::Path(s.into())
+        } else if s.trim().is_empty() {
+            Self::Auto
+        } else {
+            unreachable!()
+        })
+    }
+}
+
+impl<S> From<S> for ConfigLocation where S: AsRef<str> {
+    fn from(s: S) -> Self {
+        Self::from_str(s.as_ref()).unwrap()
+    }
+}
+
+fn get_config_dir() -> PathBuf {
+    ProjectDirs::from(
+        "ata",
+        "Ask the Terminal Anything (ATA) Project Authors",
+        "ata",
+    ).unwrap().config_dir().into()
+}
+
+pub fn default_path(name: Option<&Path>) -> PathBuf {
+    let mut config_file = get_config_dir();
+    let file: Vec<_> = if let Some(name) = name {
+        let mut name = name.to_path_buf();
+        name.set_extension("toml");
+        name.as_os_str()
+            .to_raw_bytes()
+            .iter()
+            .copied()
+            .collect()
+    } else {
+        "ata.toml".bytes().collect()
+    };
+    let file = OsString::assert_from_raw_vec(file);
+    config_file.push(&file);
+    config_file
+}
+
+impl ConfigLocation {
+    pub fn location(&self) -> PathBuf {
+        match self {
+            ConfigLocation::Auto => {
+                if self.location().exists() {
+                    return self.location();
+                }
+                default_path(None)
+            }
+            ConfigLocation::Path(pb) => {
+                pb.clone()
+            },
+            ConfigLocation::Named(name) => {
+                if name.as_os_str() == "default" {
+                    return match Path::new("ata.toml").exists() {
+                        true => Path::new(&"ata.toml").into(),
+                        false => default_path(None)
+                    };
+                }
+                default_path(Some(name))
+            }
+        }
+    }
+}
+
+impl FromStr for Config {
+    type Err = TomlError;
+
+    fn from_str(contents: &str) -> Result<Self, Self::Err> {
+        toml::from_str(contents)
+    }
+}
+
+impl<S> From<S> for Config where S: AsRef<str> {
+    fn from(s: S) -> Self {
+        Self::from_str(s.as_ref())
+            .unwrap_or_else(|e| panic!("Config parsing failure!: {:?}", e))
+    }
+}

--- a/ata/src/main.rs
+++ b/ata/src/main.rs
@@ -56,9 +56,11 @@ struct Flags {
 
 struct ClearEventHandler;
 impl ConditionalEventHandler for ClearEventHandler {
-    fn handle(&self, evt: &Event, _: RepeatCount, _: bool, _: &EventContext) -> Option<Cmd> {
-        debug_assert_eq!(*evt, Event::from(KeyEvent::ctrl('L')));
-        print_prompt();
+    fn handle(&self, _: &Event, _: RepeatCount, _: bool, _: &EventContext) -> Option<Cmd> {
+        thread::spawn(|| {
+            thread::sleep(Duration::from_millis(100));
+            print_prompt();
+        });
         Some(Cmd::ClearScreen)
     }
 }
@@ -91,9 +93,6 @@ fn main() -> prompt::TokioResult<()> {
         println!("temperature: {temperature}");
         println!();
     }
-
-    println!("Use CTRL+L to clear the screen and start a new chat.");
-    println!();
 
     if model.contains("text") {
         eprintln!("\x1b[1mWARNING:\x1b[0m\n\


### PR DESCRIPTION
Support the newly released chat API (released 1st of March 2023): `gpt-3.5-turbo`. This model is better than the text models according to Greg Brockman. Also, `gpt-3.5-turbo` is 10 times cheaper than `text-davinci-003` per token. Due to the increased complexity in supporting text models and chat models and me having only so much time in the day, this PR drops support for text models such as `text-davinci-003`. To support those again, tests should be added to the repository which mock both the OpenAI API and stdout (see https://github.com/kkawakam/rustyline/issues/652#issuecomment-1421314307 for a stdout mock example).

This PR is partially based on #21.

- Closes #19 