### PR TITLE
Avoid chopping of last character from input

### DIFF
--- a/ata/src/prompt.rs
+++ b/ata/src/prompt.rs
@@ -236,7 +236,7 @@ mod tests {
     fn leading_newlines() {
         assert_eq!(
             sanitize_input("foo\"bar".to_string()),
-            "foo\\\"ba".to_string()
+            "foo\\\"bar".to_string()
         );
     }
 

--- a/ata/src/prompt.rs
+++ b/ata/src/prompt.rs
@@ -16,8 +16,7 @@ use std::sync::Arc;
 pub type TokioResult<T, E = Box<dyn Error + Send + Sync>> = Result<T, E>;
 
 fn sanitize_input(input: String) -> String {
-    let mut out = input;
-    out.pop();
+    let out = input.trim_end_matches("\n");
     out.replace('"', "\\\"")
 }
 


### PR DESCRIPTION
fix an issue where the last character from string is chopped off regardless of if its a newline char or not